### PR TITLE
Feat: Implement delete project functionality

### DIFF
--- a/source/script.js
+++ b/source/script.js
@@ -160,6 +160,27 @@ function renderProjectDetail(projectId) {
     }
 
     detailView.appendChild(form);
+
+    const deleteButton = document.createElement('button');
+    deleteButton.textContent = 'Delete Project';
+    deleteButton.classList.add('delete-button');
+    deleteButton.addEventListener('click', () => {
+        if (confirm('Are you sure you want to delete this project? This action cannot be undone.')) {
+            projects = projects.filter(p => p.id !== projectId);
+            saveProjects();
+
+            // Go back to the main list view
+            const header = document.querySelector('header');
+            const projectListView = document.getElementById('project-list');
+            const detailView = document.getElementById('project-detail-view');
+
+            header.style.display = 'flex';
+            projectListView.style.display = 'grid';
+            detailView.style.display = 'none';
+            renderProjectList();
+        }
+    });
+    detailView.appendChild(deleteButton);
 }
 
 // --- DATA MODEL ---

--- a/source/style.css
+++ b/source/style.css
@@ -167,3 +167,12 @@ button:hover {
     min-height: 100px;
     resize: vertical;
 }
+
+.delete-button {
+    background-color: #c62828; /* Red for destructive action */
+    margin-top: 2rem;
+}
+
+.delete-button:hover {
+    background-color: #e53935;
+}


### PR DESCRIPTION
This commit introduces the ability for users to delete projects from the application.

Key Changes:
- **Added Delete Button:** A 'Delete Project' button has been added to the project editing page and styled to indicate a destructive action.
- **Confirmation Dialog:** An event listener on the delete button triggers a native browser confirmation dialog (`confirm()`) to prevent accidental deletions.
- **Deletion Logic:** If the user confirms, the selected project is removed from the `projects` array, and the change is persisted to `localStorage`.
- **UI Update:** After deletion, the user is automatically returned to the main project overview page, which then re-renders to reflect the removal of the project.